### PR TITLE
Fixed 'extra'

### DIFF
--- a/mvm/invoke.go
+++ b/mvm/invoke.go
@@ -81,11 +81,10 @@ func invokeProcessCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	extra, _ := hex.DecodeString(c.String("extra"))
 	op := &encoding.Operation{
 		Purpose: encoding.OperationPurposeGroupEvent,
 		Process: c.String("process"),
-		Extra:   extra,
+		Extra:   []byte(c.String("extra")),
 	}
 	input := mixin.TransferInput{
 		AssetID: c.String("asset"),

--- a/mvm/invoke.go
+++ b/mvm/invoke.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"


### PR DESCRIPTION
Error occurs when using `./mvm ... -extra "hello"`

`encoding/hex: invalid byte: U+0068 'h'`