### PR TITLE
Fix Collectible Name

### DIFF
--- a/mvm/machine/collectible.go
+++ b/mvm/machine/collectible.go
@@ -86,9 +86,9 @@ func (m *Machine) fetchCollectibleToken(ctx context.Context, id string) ([]byte,
 	err = m.store.WriteCollectibleToken(&CollectibleToken{
 		Id:     id,
 		Symbol: token.Token,
-		Name:   token.Group,
+		Name:   token.Meta.Group,
 	})
-	return encodeCollectibleMeta(token.Token, token.Group), err
+	return encodeCollectibleMeta(token.Token, token.Meta.Group), err
 }
 
 func encodeCollectibleMeta(symbol, name string) []byte {


### PR DESCRIPTION
Is the `Name` supposed to be the readable name of the token?

`token.Group` is like `bfcfb539009d42bd852122b0ec159c9c`

`token.Meta.Group` is like `Mixin 4th Anniversary`

If true, then it should be `token.Meta.Group`.